### PR TITLE
Added 20px of padding to the FloatingControls popup

### DIFF
--- a/src/components/workspace.js
+++ b/src/components/workspace.js
@@ -158,8 +158,8 @@ class FloatingControls extends React.Component {
             vec4.transformMat4([],
                 vec4.transformMat4([], [bounds.x1, bounds.y1, 0, 1], this.props.camera.view),
                 this.props.camera.perspective);
-        let x = ((p[0] / p[3] + 1) * this.props.workspaceWidth / 2) - 20;
-        let y = (this.props.workspaceHeight - (p[1] / p[3] + 1) * this.props.workspaceHeight / 2) + 20;
+        let x = (p[0] / p[3] + 1) * this.props.workspaceWidth / 2 - 20;
+        let y = this.props.workspaceHeight - (p[1] / p[3] + 1) * this.props.workspaceHeight / 2 + 20;
 
         x = x / window.devicePixelRatio - this.props.width;
         y = y / window.devicePixelRatio;

--- a/src/components/workspace.js
+++ b/src/components/workspace.js
@@ -158,8 +158,8 @@ class FloatingControls extends React.Component {
             vec4.transformMat4([],
                 vec4.transformMat4([], [bounds.x1, bounds.y1, 0, 1], this.props.camera.view),
                 this.props.camera.perspective);
-        let x = (p[0] / p[3] + 1) * this.props.workspaceWidth / 2;
-        let y = this.props.workspaceHeight - (p[1] / p[3] + 1) * this.props.workspaceHeight / 2;
+        let x = ((p[0] / p[3] + 1) * this.props.workspaceWidth / 2) - 20;
+        let y = (this.props.workspaceHeight - (p[1] / p[3] + 1) * this.props.workspaceHeight / 2) + 20;
 
         x = x / window.devicePixelRatio - this.props.width;
         y = y / window.devicePixelRatio;


### PR DESCRIPTION
During testing with the 2 point path and line issues the fact that the FloatingControls popup was at the exact bottom left of the selected object felt very crowded. Sometimes it looked like the feature continued on behind the popup (It didn't)

I added 20px of padding to the coord math so the TOC collision check still works.