### PR TITLE
DXF text support

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "dxf-parser": "^0.4.6",
     "immutability-helper": "^2.0.0",
     "react-addons-shallow-compare": "^15.4.1",
-    "unicode": "^0.6.1"
+    "unicode": "^0.6.1",
+    "vectorize-text": "^3.0.2"
   }
 }

--- a/src/lib/dxf.js
+++ b/src/lib/dxf.js
@@ -259,16 +259,25 @@ function drawText(state, entity, docLayer, index) {
     let pixleSize = 1;
 
     if (entity.type == "MTEXT") {
-        const regex = /\{\\f(.*?)\|(\w+)\|(\w+)\|(\w+)\|(\w+)\;(.*?)\}$/g;
-        //const str = `{\\fTimes New Roman|b0|i0|c0|p0;call.me({obj});}`;
+        let regex = /\{\\f(.*?)\|(\w+)\|(\w+)\|(\w+)\|(\w+)\;(.*?)\}$/g;
         let regexString = regex.exec(entity.text); // 0: origStrng, 1: font, 2: bold, 3: italics, 6: text
-        console.log(regexString)
-
-        let style, weight;
-        if (regexString[2] == 'b1')
-            entity.fontWeight = 'bold';
-        if (regexString[3] == 'i1')
-            entity.fontWeight = 'italic';
+        if (regexString) {
+            let style, weight;
+            if (regexString[2] == 'b1')
+                entity.fontWeight = 'bold';
+            if (regexString[3] == 'i1')
+                entity.fontWeight = 'italic';
+            if (regexString[1])
+                entity.fontFamily = regexString[1];
+            if (regexString[6])
+                entity.text = regexString[6];
+        } else {
+            regex = /\{(.*?)\}$/g;
+            regexString = regex.exec(entity.text);
+            if (regexString) {
+                entity.text = regexString[1];
+            }
+        }
 
         entity = {
             ...entity,
@@ -277,8 +286,6 @@ function drawText(state, entity, docLayer, index) {
                 y: entity.position.y
             },
             textHeight: entity.height,
-            fontFamily: regexString[1],
-            text: regexString[6],
         }
     }
 

--- a/src/lib/dxf.js
+++ b/src/lib/dxf.js
@@ -230,6 +230,15 @@ function drawText(state, entity, docLayer, index) {
         name: entity.type + ': ' + entity.handle,
     }
 
+    // Create defualt font settings
+    entity = {
+        ...entity,
+        fontStyle: 'normal', // normal italic oblique
+        fontWeight: 'normal', // normal bold
+        fontFamily: 'Ariel',
+    }
+
+
     let magicDPIScale = 0.37;
     let magicFontHeight = 6;
     let pixleSize = 1; //
@@ -242,6 +251,7 @@ function drawText(state, entity, docLayer, index) {
                 y: entity.position.y
             },
             textHeight: entity.height,
+            text: 'regex_here', // regex needed
         }
     }
 
@@ -249,7 +259,7 @@ function drawText(state, entity, docLayer, index) {
     cvs.width = '1000';
     cvs.height = '1000';
     var ctx = cvs.getContext('2d');
-    ctx.font = entity.textHeight + "mm Arial";
+    ctx.font = entity.fontStyle + ' ' + entity.fontWeight + ' ' + entity.textHeight + 'mm ' + entity.fontFamily;
     ctx.scale(1, -1);
     ctx.fillText(entity.text, 0, - 100); // add 100 for font tails. eg, pjg
 

--- a/src/lib/dxf.js
+++ b/src/lib/dxf.js
@@ -248,8 +248,8 @@ function drawText(state, entity, docLayer, index) {
     // Create defualt font settings
     entity = {
         ...entity,
-        fontStyle: 'normal', // normal italic oblique
-        fontWeight: 'normal', // normal bold
+        fontStyle: '', // normal italic oblique
+        fontWeight: '', // normal bold
         fontFamily: 'Ariel',
     }
 
@@ -259,6 +259,17 @@ function drawText(state, entity, docLayer, index) {
     let pixleSize = 1;
 
     if (entity.type == "MTEXT") {
+        const regex = /\{\\f(.*?)\|(\w+)\|(\w+)\|(\w+)\|(\w+)\;(.*?)\}$/g;
+        //const str = `{\\fTimes New Roman|b0|i0|c0|p0;call.me({obj});}`;
+        let regexString = regex.exec(entity.text); // 0: origStrng, 1: font, 2: bold, 3: italics, 6: text
+        console.log(regexString)
+
+        let style, weight;
+        if (regexString[2] == 'b1')
+            entity.fontWeight = 'bold';
+        if (regexString[3] == 'i1')
+            entity.fontWeight = 'italic';
+
         entity = {
             ...entity,
             startPoint: {
@@ -266,7 +277,8 @@ function drawText(state, entity, docLayer, index) {
                 y: entity.position.y
             },
             textHeight: entity.height,
-            text: 'regex_here', // regex needed
+            fontFamily: regexString[1],
+            text: regexString[6],
         }
     }
 

--- a/src/lib/dxf.js
+++ b/src/lib/dxf.js
@@ -229,21 +229,23 @@ function drawText(state, entity, docLayer, index) {
         type: entity.type,
         name: entity.type + ': ' + entity.handle,
     }
-    let magicTranslate = 100;
-    let magicFontHeight = 0.357; // 0.357 for DPI 0.5
-    let magicDPIScale = 0.75;
-    let magicPixleScale = 0.5; // This needs to be a function of DPI, >font:>pixles
+    // from mesh.js
+    const inchToClipperScale = 1270000000;
+    const mmToClipperScale = inchToClipperScale / 25.4; // 50,000,000;
+    const clipperToCppScale = 1 / 128;
+
+    //let magicTranslate = 100;
+    let magicDPIScale = 1/4.28;
+    let magicFontHeight = 6;
+    let pixleSize = 1; //
 
     var cvs = document.createElement('canvas');
     cvs.width = '1000';
     cvs.height = '1000';
     var ctx = cvs.getContext('2d');
-    //ctx.font = entity.textHeight + "px Arial";
-    ctx.font = entity.textHeight / magicFontHeight + "px Arial";
-    //ctx.fillText(entity.text, entity.startPoint.x/magicDPIScale, (-entity.startPoint.y/magicDPIScale) + magicTranslate);
-    //ctx.fillText(entity.text, entity.startPoint.x, -entity.startPoint.y + magicTranslate);
-    ctx.scale(1, 1);
-    ctx.fillText(entity.text, entity.startPoint.x, cvs.height-entity.startPoint.y);
+    ctx.font = entity.textHeight * magicFontHeight + "px Arial";
+    ctx.scale(1, -1);
+    ctx.fillText(entity.text, 0, 0);
 
     let data = ctx.getImageData(0, 0, cvs.width, cvs.height);
     let coords = [];
@@ -256,22 +258,15 @@ function drawText(state, entity, docLayer, index) {
             y++;
         }
         if (data.data[i+3]) {
-            // 96 dpi	1 px	0.264583 mm
-            let dx = x * magicDPIScale;
-            let dy = -y * magicDPIScale;
-            coords.push([dx,dy,dx+magicPixleScale,dy,dx+magicPixleScale,dy+magicPixleScale,dx,dy+magicPixleScale,dx,dy])
+            coords.push([x,y,x+pixleSize,y,x+pixleSize,y+pixleSize,x,y+pixleSize,x,y])
         }
         x++;
     }
 
-    //FileStorage.save(prompt("Save as", "coords.json"), JSON.stringify(coords), "application/json")
-
     if (coords.length) {
-        //docEntity.rawPaths = [];
         docEntity.rawPaths = coords;
-        //docEntity.translate = [0, magicTranslate/2, 0];
-        docEntity.translate = [0, 0, 0];
-        docEntity.scale = [1, 1, 1];
+        docEntity.translate = [entity.startPoint.x, entity.startPoint.y, 0];
+        docEntity.scale = [magicDPIScale, magicDPIScale, 1];
         docEntity.strokeColor = [0, 0, 0, 1];
         docEntity.fillColor = [0, 0, 0, 1];
     }


### PR DESCRIPTION
Basic text support working. 

Draws to canvas using the system fonts so no font handling is required. Pixel data is extrapolated from the offscreen canvas and then scaled to fit the workspace canvas. Large text is a resource hog as the font is especially thousands of tiny squares will fill.

TODO: Come up with an algorithm to trace the shape outline into line segments or ultimately curves.

Not supported:
* Text rotation
* Multiple styles in a single MTEXT