### PR TITLE
Seems to work now when moving the workspace viewport around.

### DIFF
--- a/src/components/workspace.js
+++ b/src/components/workspace.js
@@ -586,7 +586,7 @@ class WorkspaceContent extends React.Component {
             gl.disable(gl.BLEND);
             let r = ReactDOM.findDOMNode(this.canvas).getBoundingClientRect();
             let x = Math.round(pageX * window.devicePixelRatio - r.left);
-            let y = Math.round(this.props.height - pageY * window.devicePixelRatio - r.top);
+            let y = Math.round(this.props.height - pageY * window.devicePixelRatio + r.top);
             if (x >= 0 && x < this.props.width && y >= 0 && y < this.props.height) {
                 drawDocumentsHitTest(this.camera.perspective, this.camera.view, this.drawCommands, this.props.documentCacheHolder);
                 let pixel = new Uint8Array(4);


### PR DESCRIPTION
Hi guys,

I noticed the `y` value was incorrectly substracting top of bounding rectangle and thus making it harder to hit objects for selection if I moved the viewport around.

Here is a pull request.