### PR TITLE
Bump dxf-parser to v.0.4.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
   },
   "dependencies": {
     "bootstrap-range-input": "^1.0.0",
-    "dxf-parser": "^0.4.6",
+    "dxf-parser": "^0.4.7",
     "immutability-helper": "^2.0.0",
     "unicode": "^0.6.1",
     "vectorize-text": "^3.0.2"


### PR DESCRIPTION
Fixes complex entity fields not compounding correctly.