### PR TITLE
Bump dxf-parser version

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
   },
   "dependencies": {
     "bootstrap-range-input": "^1.0.0",
-    "dxf-parser": "^0.4.7",
+    "dxf-parser": "^0.4.8",
     "immutability-helper": "^2.0.0",
     "unicode": "^0.6.1",
     "vectorize-text": "^3.0.2"


### PR DESCRIPTION
V0.4.8 fixes shape issues and adds a few new features I will make use of in the future.