### PR TITLE
Add experimental support for a different travel speed (#433)

### DIFF
--- a/src/components/operation.js
+++ b/src/components/operation.js
@@ -509,6 +509,7 @@ export const OPERATION_FIELDS = {
 
     plungeRate: { name: 'plungeRate', label: 'Plunge Rate', units: 'mm/min', input: NumberInput, ...checkFeedRateRange('Z') },
     cutRate: { name: 'cutRate', label: 'Cut Rate', units: 'mm/min', input: NumberInput, ...checkFeedRateRange('XY'), contextMenu: FieldContextMenu() },
+    rapidRate: { name: 'rapidRate', label: 'Rapid Rate', units: 'mm/min', input: NumberInput, ...checkFeedRateRange('XY') },
     toolSpeed: { name: 'toolSpeed', label: 'Tool Speed (0=Off)', units: 'rpm', input: NumberInput, ...checkFeedRateRange('S') },
 
     useA: { name: 'useA', label: 'Use A Axis', units: '', input: ToggleInput, contextMenu: FieldContextMenu() },
@@ -573,7 +574,7 @@ export const OPERATION_TYPES = {
     'Laser Fill Path': { allowTabs: false, tabFields: false, fields: ['name', 'filterFillColor', 'filterStrokeColor', 'lineDistance', 'lineAngle', 'laserPower', 'margin', 'passes', 'passDepth', 'startHeight', 'cutRate', 'useA', 'aAxisDiameter', 'useBlower', ...OPERATION_GROUPS.Macros.fields] },
     'Laser Raster': {
         allowTabs: false, tabFields: false, fields: [
-            'name', 'laserPowerRange', 'laserDiameter', 'passes', 'passDepth', 'startHeight', 'cutRate', 'useBlower',
+            'name', 'laserPowerRange', 'laserDiameter', 'passes', 'passDepth', 'startHeight', 'cutRate', 'rapidRate', 'useBlower',
             'trimLine', 'joinPixel', 'burnWhite', 'verboseGcode', 'diagonal', 'overScan', 'useA', 'aAxisDiameter',
             ...OPERATION_GROUPS.Filters.fields, ...OPERATION_GROUPS.Macros.fields
         ]

--- a/src/lib/cam-gcode-raster.js
+++ b/src/lib/cam-gcode-raster.js
@@ -74,11 +74,14 @@ export function getLaserRasterGcodeFromOp(settings, opIndex, op, docsWithImages,
                 });
 
             }
-            if (line[0] !== 'S' && line.substring(0, 4) !== 'G0 F') {
-                raster += line + '\r\n';
-            } else {
-                raster += '; stripped: ' + line + '\r\n';
-            }
+            // Why?
+            // if (line[0] !== 'S' && line.substring(0, 4) !== 'G0 F') {
+            //     raster += line + '\r\n';
+            // } else {
+            //     raster += '; stripped: ' + line + '\r\n';
+            // }
+
+            raster += line + '\r\n';
         }
 
         raster += '\r\n\r\n';
@@ -180,7 +183,7 @@ export function getLaserRasterGcodeFromOp(settings, opIndex, op, docsWithImages,
                     toolDiameter: op.laserDiameter,
                     beamRange: { min: 0, max: settings.gcodeSMaxValue },
                     beamPower: op.laserPowerRange, //Go go power rangeR!
-                    rapidRate: false,
+                    rapidRate: op.rapidRate,
                     feedRate,
                     offsets: { 
                         X: (docBounds.x1 + docBounds.x2 - w / settings.dpiBitmap * 25.4) / 2 + doc.transform2d[4],


### PR DESCRIPTION
As described in my issue (https://github.com/LaserWeb/LaserWeb4/issues/433) already, I looked for a way to increase engrave speed by setting a different speed for travel movements. It seems that this was more or less already implemented and I made some changes in order to activate it.

Could you please give me some advice if I'm going in the right direction?