### PR TITLE
Fix grayscale algorithm

### DIFF
--- a/src/lib/lw.raster2gcode/canvas-filters.js
+++ b/src/lib/lw.raster2gcode/canvas-filters.js
@@ -116,7 +116,7 @@ function grayscale(data, i, algorithm, shades) {
 
     // Shades of gray
     if (shades !== undefined) {
-        gray = parseInt(gray / shades) * shades
+        gray = Math.round(gray / shades) * shades
     }
 
     // Force integer


### PR DESCRIPTION
Replacing `parseInt` with `Math.round` gives the _closest_ shade of gray instead of truncating to the _darkest_ neighboring shade.
Currently, using `parseInt` with `shadesOfGray= 2` forces all non-white colors to black.