### PR TITLE
Tweak math ordering to fix #479

### DIFF
--- a/src/components/workspace.js
+++ b/src/components/workspace.js
@@ -312,7 +312,7 @@ class FloatingControls extends React.Component {
         }
 
         this.toolOptimize = (doc, scale, anchor = 'C') => {
-            if (!scale) scale = 25.4 / this.props.settings.dpiBitmap;
+            if (!scale) scale = 1.0 / (this.props.settings.dpiBitmap / 25.4);
             if (doc.originalPixels) {
                 let targetwidth = doc.originalPixels[0] * scale;
                 let targetheight = doc.originalPixels[1] * scale;

--- a/src/lib/mesh.js
+++ b/src/lib/mesh.js
@@ -4,12 +4,12 @@
 // it under the terms of the GNU Affero General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU Affero General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
@@ -88,7 +88,7 @@ function linearizeSnapPath(path, minNumSegments, minSegmentLength, alertFn) {
     return result;
 };
 
-// Get linear paths (snap format) from an SVG element. Calls alertFn with an 
+// Get linear paths (snap format) from an SVG element. Calls alertFn with an
 // error message and returns null if there's a problem.
 function elementToLinearSnapPaths(element, minNumSegments, minSegmentLength, alertFn) {
     let path = null;
@@ -134,7 +134,7 @@ function elementToLinearSnapPaths(element, minNumSegments, minSegmentLength, ale
 // Result is in mm. Returns multiple paths. Only supports linear paths.
 // Calls alertFn with an error message and returns null if there's a problem.
 function snapPathToRawPaths(snapPath, pxPerInch, alertFn) {
-    let factor = 25.4 / pxPerInch;
+    let factor = 1.0 / (pxPerInch / 25.4);
     if (snapPath.length < 2 || snapPath[0].length != 3 || snapPath[0][0] != 'M') {
         alertFn('Path does not begin with M');
         return null;

--- a/src/reducers/document.js
+++ b/src/reducers/document.js
@@ -234,7 +234,7 @@ function processImage(doc, settings, context) {
 
 function loadImage(state, settings, { file, content, context }, id = uuidv4()) {
     state = state.slice();
-    let scale = 25.4 / settings.dpiBitmap;
+    let scale = 1.0 / (settings.dpiBitmap / 25.4);
     let doc = {
         ...DOCUMENT_INITIALSTATE,
         id: id,
@@ -326,7 +326,7 @@ export function cloneDocument(forest, rootId, renamer=(d)=>(d.name))
             item.children=item.children.map(c=>(idMap[c]));
             return item;
         })
-    
+
     return docs;
 }
 
@@ -336,7 +336,7 @@ export function documents(state, action) {
         case 'DOCUMENT_SELECT': {
             let ids = getSubtreeIds(state, action.payload.id);
             return state.map(o => Object.assign({}, o, { selected: ids.includes(o.id) }));
-            
+
         }
 
         case 'DOCUMENT_TOGGLE_SELECT': {
@@ -381,7 +381,7 @@ export function documents(state, action) {
                         return `${p} (${countOf(p)})`
                     }) : `${d.name} (${countOf(d.name)})`
                 })
-                if (cloned.length) 
+                if (cloned.length)
                     clones= [...clones,...cloned];
             })
 
@@ -400,7 +400,7 @@ export function documents(state, action) {
             return state.map((o)=>{
                 if (!o.selected) return o;
                 return Object.assign({},o,action.payload.color)
-            }) 
+            })
             return state;
         }
 


### PR DESCRIPTION
This fixes issue #479.  I replaced all remaining instances of 24.5 being used in the numerator with the "inverted" form originally found in [`cam-gcode-raster.js`](https://github.com/LaserWeb/LaserWeb4/blob/bf1ff64a9b4c535137c3a9189bdd8e3d1e85aac7/src/lib/cam-gcode-raster.js#L158).