### PR TITLE
Reenable viewBox coordinate transformation in the SVG parser

### DIFF
--- a/src/lib/lw.svg-parser/tagparser.js
+++ b/src/lib/lw.svg-parser/tagparser.js
@@ -375,8 +375,8 @@ class TagParser {
             }
         }
 
-        //this.tag.scale(scaleX, scaleY)
-        //this.tag.translate(-translateX, -translateY)
+        this.tag.translate(-translateX, -translateY)
+        this.tag.scale(scaleX, scaleY)
     }
 
     // Parse transform attribute and set transformations


### PR DESCRIPTION
I get users complaining that the SVGs I generate with Boxes.py (https://github.com/florianfesti/boxes) cannot be rendered with Laserweb. A quick look raised the suspicion that the viewBox calculation may be off. Well, ViewBox transformation was commented out.

Turns out the commented out code was actually wrong as it did scale the
coordinates first and then move the starting corner to the origin.
For this to work properly the starting corner needs to be move to the origin
first and coordinates must only scaled after that to ensure the starting corner
actually ends up on the origin.

