### PR TITLE
Update to support comm server move to Node10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "7"
+  - "10"
 sudo: required
 dist: trusty
 before_install:


### PR DESCRIPTION
Update to support NodeJS v10 for lw.comm-server.  See pull request [this pull request](https://github.com/LaserWeb/lw.comm-server/pull/69) from that project for more details.  This is needed to make the electron builder work properly.