### PR TITLE
Add a basic .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
Noticed most files in this repo use a slightly different style than my editor defaults. (Primarily, tabs are 4 spaces in this repo; my personal preference is 2). Adding this file to make it easier to switch between projects. More info at https://editorconfig.org/