### PR TITLE
Media devices ssl

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3747,7 +3747,7 @@
     },
     "gamepad.js": {
       "version": "git+https://github.com/neogeek/gamepad.js.git#d3f8f96e790732f0ccb95eec70c89b14e0138dc0",
-      "from": "git+https://github.com/neogeek/gamepad.js.git",
+      "from": "git+https://github.com/neogeek/gamepad.js.git#d3f8f96e79",
       "dev": true
     },
     "gamma": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "flat": "^2.0.1",
     "floyd-steinberg": "^1.0.6",
     "font-awesome": "^4.6.3",
-    "gamepad.js": "git+https://github.com/neogeek/gamepad.js.git",
+    "gamepad.js": "git+https://github.com/neogeek/gamepad.js.git#d3f8f96e79",
     "gl-matrix": "^2.3.2",
     "hhmmss": "^1.0.0",
     "imports-loader": "^0.7.1",

--- a/src/components/settings.js
+++ b/src/components/settings.js
@@ -312,29 +312,38 @@ class Settings extends React.Component {
                     </SettingsPanel>
 
                     <Panel collapsible header="Camera" bsStyle="info" eventKey="6">
-                        <table width="100%"><tbody><tr>
-                            <td width="45%"><VideoDeviceField {...{ object: this.props.settings, field: 'toolVideoDevice', setAttrs: setSettingsAttrs, description: 'Video Device', disabled: !!this.props.settings['toolWebcamUrl']}} /></td>
-                            <td width="45%"><VideoResolutionField {...{ object: this.props.settings, field: 'toolVideoResolution', setAttrs: setSettingsAttrs, deviceId: this.props.settings['toolVideoDevice'] }} /></td>
 
-                        </tr></tbody></table>
+                        <div id="novideodevices" style={{ display: "none" }}>
+                            <h5 className="header">Video Device List Unavailable</h5>
+                            <small className="help-block">This may be due to running over an insecure connection, blocking in browser preferences, or other 3rd party security protections.</small>
+                        </div>
+
+                        <div id="localvideodevices">
+                            <table width="100%"><tbody><tr>
+                                <td width="45%"><VideoDeviceField {...{ object: this.props.settings, field: 'toolVideoDevice', setAttrs: setSettingsAttrs, description: 'Video Device', disabled: !!this.props.settings['toolWebcamUrl']}} /></td>
+                                <td width="45%"><VideoResolutionField {...{ object: this.props.settings, field: 'toolVideoResolution', setAttrs: setSettingsAttrs, deviceId: this.props.settings['toolVideoDevice'] }} /></td>
+
+                            </tr></tbody></table>
+
+                            <ToggleField  {... { object: this.props.settings, field: 'toolVideoOMR', setAttrs: setSettingsAttrs, description: 'Activate OMR', info: Info(<p className="help-block">
+                            Enabling this, ARUCO markers will be recognized by floating camera port, allowing stock alignment. <Label bsStyle="warning">Experimental!</Label>
+                            </p>,"Optical Mark Recognition"), disabled:!this.props.settings['toolVideoDevice'] }} />
+
+                            <Collapse in={this.props.settings.toolVideoOMR}>
+                                <div>
+                                    <NumberField {...{ object: this.props.settings, field: 'toolVideoOMROffsetX', setAttrs: setSettingsAttrs, description: 'Camera offset X', units:'mm'  }} />
+                                    <NumberField {...{ object: this.props.settings, field: 'toolVideoOMROffsetY', setAttrs: setSettingsAttrs, description: 'Camera offset Y', units:'mm' }} />
+                                    <NumberField {...{ object: this.props.settings, field: 'toolVideoOMRMarkerSize', setAttrs: setSettingsAttrs, description: 'Marker size', units:'mm' }} />
+                                    <ArucoMarker />
+                                </div>
+                            </Collapse>
+                        </div>
+
+                        <hr/>
 
                         <VideoPort height={240} enabled={(this.props.settings['toolVideoDevice'] !== null) || (this.props.settings['toolWebcamUrl'])} />
 
                         <TextField   {... { object: this.props.settings, field: 'toolWebcamUrl', setAttrs: setSettingsAttrs, description: 'Webcam Url' }} disabled={this.props.settings['toolVideoDevice'] !== null} />
-                        <hr/>
-                        <ToggleField  {... { object: this.props.settings, field: 'toolVideoOMR', setAttrs: setSettingsAttrs, description: 'Activate OMR', info: Info(<p className="help-block">
-                        Enabling this, ARUCO markers will be recognized by floating camera port, allowing stock alignment. <Label bsStyle="warning">Experimental!</Label>
-                        </p>,"Optical Mark Recognition"), disabled:!this.props.settings['toolVideoDevice'] }} />
-
-                        <Collapse in={this.props.settings.toolVideoOMR}>
-                            <div>
-                                <NumberField {...{ object: this.props.settings, field: 'toolVideoOMROffsetX', setAttrs: setSettingsAttrs, description: 'Camera offset X', units:'mm'  }} />
-                                <NumberField {...{ object: this.props.settings, field: 'toolVideoOMROffsetY', setAttrs: setSettingsAttrs, description: 'Camera offset Y', units:'mm' }} />
-                                <NumberField {...{ object: this.props.settings, field: 'toolVideoOMRMarkerSize', setAttrs: setSettingsAttrs, description: 'Marker size', units:'mm' }} />
-                                <ArucoMarker />
-                            </div>
-                        </Collapse>
-
                         
                     </Panel>
 

--- a/src/components/settings.js
+++ b/src/components/settings.js
@@ -315,7 +315,7 @@ class Settings extends React.Component {
 
                         <div id="novideodevices" style={{ display: "none" }}>
                             <h5 className="header">Video Device List Unavailable</h5>
-                            <small className="help-block">This may be due to running over an insecure connection, blocking in browser preferences, or other 3rd party security protections.</small>
+                            <small className="help-block">This may be due to running over an insecure connection, blocking in browser preferences, or other privacy protections.</small>
                         </div>
 
                         <div id="localvideodevices">

--- a/src/lib/video-capture.js
+++ b/src/lib/video-capture.js
@@ -196,6 +196,14 @@ export class VideoCapture {
             let cameras = [];
             cameras.push({ label: "None", value: null })
             callback(cameras)
+            var lvd = document.getElementById("localvideodevices");
+            if (lvd) {
+              lvd.style.display = "none";
+            }
+            var ndv = document.getElementById("novideodevices");
+            if (ndv) {
+               ndv.style.display = "block";
+            }
         } else {
             let promise = navigator.mediaDevices.enumerateDevices();
             let that = this;
@@ -210,6 +218,14 @@ export class VideoCapture {
             }).catch(function (err) {
                 console.error(err.name + ": " + err.message);
             });
+            var lvd = document.getElementById("localvideodevices");
+            if (lvd) {
+              lvd.style.display = "block";
+            }
+            var ndv = document.getElementById("novideodevices");
+            if (ndv) {
+               ndv.style.display = "none";
+            }
         }
     }
 


### PR DESCRIPTION
Restores Broken `Tool`, `Menu` and `Camera URL` Settings for users affected by recent chrome security-ratchet changes to camera access resulting in inaccessible settings items and (in chrome console):

    Uncaught TypeError: Cannot read property 'enumerateDevices' of undefined
    at VideoCapture.getDevices (video-capture.js:194) 

It now checks if the device list can be enumerated before attempting to do so, and only displays device selector + omr control if available. Otherwise it displays a 'Device List Unavalable' message + hint. 

See: https://forum.makerforums.info/t/tools-and-macro-menus-not-responsive-after-fresh-install-of-laserweb4/77783

The initial commit of this is a 'vanilla' fix that fixes the problem as minimally as possible.
The full PR takes care of giving the user some meaningful feedback instead of simply displaying an empty selector dialogue.

![Screenshot from 2020-08-16 18-08-23](https://user-images.githubusercontent.com/4005142/90338680-9cd90b80-dfeb-11ea-825e-c379f263f934.png)

PS: There is probably a ver 'React friendly' way to do this, but I chose to shortcut that with element ID's and setting style tags. So I consider this sort of incomplete but I dont have time/space to learn react.js ;-)