### PR TITLE
Peg the version of gamepad.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3747,7 +3747,7 @@
     },
     "gamepad.js": {
       "version": "git+https://github.com/neogeek/gamepad.js.git#d3f8f96e790732f0ccb95eec70c89b14e0138dc0",
-      "from": "git+https://github.com/neogeek/gamepad.js.git",
+      "from": "git+https://github.com/neogeek/gamepad.js.git#d3f8f96e79",
       "dev": true
     },
     "gamma": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "flat": "^2.0.1",
     "floyd-steinberg": "^1.0.6",
     "font-awesome": "^4.6.3",
-    "gamepad.js": "git+https://github.com/neogeek/gamepad.js.git",
+    "gamepad.js": "git+https://github.com/neogeek/gamepad.js.git#d3f8f96e79",
     "gl-matrix": "^2.3.2",
     "hhmmss": "^1.0.0",
     "imports-loader": "^0.7.1",


### PR DESCRIPTION
[Gamepad.js](https://github.com/neogeek/gamepad.js) development has restarted (after 3+ years), and the developer has switched the default to a development branch and started making changes that break the LaserWeb build.
This PR specifies the last 'good' version on the main branch in `package.json` and `package-lock.json` for `gamepad.js`