### PR TITLE
fix dockerfile with public repositories

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ COPY . .
 # ---- Dependencies ----
 FROM base AS dependencies
 RUN apk add --no-cache make gcc g++ python python3 linux-headers udev git
+RUN git config --global url."https://github.com".insteadOf "ssh://git@github.com"
 # install node packages
 RUN npm set progress=false && npm config set depth 0
 RUN npm ci


### PR DESCRIPTION
The actual dockerfile isn't able to run because of ssh abilities.
We could setup a ssh client and send the ssh key in, or create a new one inside but since all dependencies are public, it is easier to just change it to http.