### PR TITLE
(1/2) Support for secure WebSockets

### DIFF
--- a/src/components/com.js
+++ b/src/components/com.js
@@ -68,9 +68,10 @@ class Com extends React.Component {
         let that = this;
         let {settings, dispatch} = this.props;
         let server = settings.comServerIP;
+        let protocol = settings.comServerSecure ? 'wss:' : 'ws:';
         CommandHistory.write('Connecting to Server @ ' + server, CommandHistory.INFO);
         //console.log('Connecting to Server ' + server);
-        socket = io('ws://' + server);
+        socket = io(protocol + '//' + server);
 
         socket.on('connect', function(data) {
             serverConnected = true;
@@ -508,6 +509,9 @@ class Com extends React.Component {
                 <PanelGroup>
                     <Panel collapsible header="Server Connection" bsStyle="primary" eventKey="1" defaultExpanded={false}>
                         <TextField {...{ object: settings, field: 'comServerIP', setAttrs: setSettingsAttrs, description: 'Server IP' }} />
+			<div className="toggleField">
+                            <ToggleField {...{ object: settings, field: 'comServerSecure', setAttrs: setSettingsAttrs, description: 'Secure connection' }} />
+                        </div>
                         <ButtonGroup>
                             <Button id="connectS" bsClass="btn btn-xs btn-info" onClick={(e)=>{this.handleConnectServer(e)}}><Icon name="share" /> Connect</Button>
                             <Button id="disconnectS" bsClass="btn btn-xs btn-danger" onClick={(e)=>{this.handleDisconnectServer(e)}}><Glyphicon glyph="trash" /> Disconnect</Button>

--- a/src/reducers/settings.js
+++ b/src/reducers/settings.js
@@ -136,6 +136,7 @@ export const SETTINGS_INITIALSTATE = {
 
     comServerVersion: 'not connected',
     comServerIP: 'localhost:8000',
+    comServerSecure: false,
     comServerConnect: false,
     comInterfaces: [],
     comPorts: [],


### PR DESCRIPTION
First of all: Thank you for this great piece of software.

This PR allows LaserWeb to be used with HTTPS-enabled servers. It adds a new checkbox in the _Server Connection_ tab to connect over a secure WebSocket (wss://) when trying to reach the backend. This setting is unchecked by default, which reflects the current behavior and should not cause any side effects.

Apache, nginx, stunnel or another reverse proxy is required to encrypt the channel as the lw.comm-server does not (yet) support SSL/TLS.

I will create another PR to automatically fill this setting. It's just a one-liner. However, it may be worth discussing.