### PR TITLE
(2/2) Guess backend server

### DIFF
--- a/src/components/com.js
+++ b/src/components/com.js
@@ -68,9 +68,10 @@ class Com extends React.Component {
         let that = this;
         let {settings, dispatch} = this.props;
         let server = settings.comServerIP;
+        let protocol = settings.comServerSecure ? 'wss:' : 'ws:';
         CommandHistory.write('Connecting to Server @ ' + server, CommandHistory.INFO);
         //console.log('Connecting to Server ' + server);
-        socket = io('ws://' + server);
+        socket = io(protocol + '//' + server);
 
         socket.on('connect', function(data) {
             serverConnected = true;
@@ -508,6 +509,9 @@ class Com extends React.Component {
                 <PanelGroup>
                     <Panel collapsible header="Server Connection" bsStyle="primary" eventKey="1" defaultExpanded={false}>
                         <TextField {...{ object: settings, field: 'comServerIP', setAttrs: setSettingsAttrs, description: 'Server IP' }} />
+			<div className="toggleField">
+                            <ToggleField {...{ object: settings, field: 'comServerSecure', setAttrs: setSettingsAttrs, description: 'Secure connection' }} />
+                        </div>
                         <ButtonGroup>
                             <Button id="connectS" bsClass="btn btn-xs btn-info" onClick={(e)=>{this.handleConnectServer(e)}}><Icon name="share" /> Connect</Button>
                             <Button id="disconnectS" bsClass="btn btn-xs btn-danger" onClick={(e)=>{this.handleDisconnectServer(e)}}><Glyphicon glyph="trash" /> Disconnect</Button>

--- a/src/reducers/settings.js
+++ b/src/reducers/settings.js
@@ -135,8 +135,8 @@ export const SETTINGS_INITIALSTATE = {
     gcodeCurvePrecision: 0.1,
 
     comServerVersion: 'not connected',
-    comServerIP: 'localhost:8000',
-    comServerSecure: false,
+    comServerIP: (typeof location.host === 'undefined') ? 'localhost:8000' : location.host,
+    comServerSecure: (typeof location.protocol === 'undefined') ? false : (location.protocol === 'https:'),
     comServerConnect: false,
     comInterfaces: [],
     comPorts: [],

--- a/src/reducers/settings.js
+++ b/src/reducers/settings.js
@@ -136,6 +136,7 @@ export const SETTINGS_INITIALSTATE = {
 
     comServerVersion: 'not connected',
     comServerIP: 'localhost:8000',
+    comServerSecure: false,
     comServerConnect: false,
     comInterfaces: [],
     comPorts: [],


### PR DESCRIPTION
PR #666 should be applied before this one, but there is no hard dependency between them.

This modifies LaserWeb's default configuration for accessing the backend server. Instead of using _localhost:8000_, it uses the hostname of the web server that served the frontend.

The change enables LaserWeb to automatically find the correct address when it is bundled with lw.comm-server. But users can still choose to use a different server if they prefer. It should work with any browser. However, if auto-detection is not available, the software will fall back to the previous defaults.